### PR TITLE
Integration with JaCoCo and SonarCloud

### DIFF
--- a/.github/workflows/code-quality-check.yml
+++ b/.github/workflows/code-quality-check.yml
@@ -1,0 +1,49 @@
+name: Code quality check
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+
+      - name: checkout current repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of sonarqube analysis
+
+      - name: Build with Maven
+        run: mvn clean -fae jacoco:prepare-agent test jacoco:report
+
+        # Runs a set of commands using the runners shell
+
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+      - name: Cache Maven packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Build and analyze
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,6 @@
 		<sonar.moduleKey>${project.groupId}:${project.artifactId}</sonar.moduleKey>
 		<sonar.organization>janssenproject</sonar.organization>
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
-
 	</properties>
 
 	<prerequisites>
@@ -42,6 +41,21 @@
 			<id>gluu</id>
 			<name>gluu repository</name>
 			<url>https://ox.gluu.org/maven</url>
+		</repository>
+		<repository>
+			<id>mavencentral</id>
+			<name>maven central</name>
+			<url>https://repo1.maven.org/maven2</url>
+		</repository>
+		<repository>
+			<id>jans</id>
+			<name>Janssen project repository</name>
+			<url>https://maven.jans.io/maven</url>
+		</repository>
+		<repository>
+			<id>bouncycastle</id>
+			<name>Bouncy Castle</name>
+			<url>https://repo2.maven.org/maven2/org/bouncycastle</url>
 		</repository>
 	</repositories>
 
@@ -76,7 +90,7 @@
 			<dependency>
 				<groupId>io.jans</groupId>
 				<artifactId>jans-auth-model</artifactId>
-                                <version>${project.version}</version>
+				<version>${project.version}</version>
 			</dependency>
             <dependency>
                 <groupId>io.jans</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,14 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		
 		<janssen.version>1.0.0-SNAPSHOT</janssen.version>
+
+		<jacoco.version>0.8.7</jacoco.version>
+
+		<sonar.projectKey>JanssenProject_jans-fido2</sonar.projectKey>
+		<sonar.moduleKey>${project.groupId}:${project.artifactId}</sonar.moduleKey>
+		<sonar.organization>janssenproject</sonar.organization>
+		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
+
 	</properties>
 
 	<prerequisites>
@@ -133,6 +141,11 @@
 					<groupId>org.codehaus.mojo</groupId>
 					<artifactId>findbugs-maven-plugin</artifactId>
 					<version>3.0.4</version>
+				</plugin>
+				<plugin>
+					<groupId>org.jacoco</groupId>
+					<artifactId>jacoco-maven-plugin</artifactId>
+					<version>${jacoco.version}</version>
 				</plugin>
 			</plugins>
 		</pluginManagement>


### PR DESCRIPTION
This PR integrates jans-fido2 repo with SonarCloud and adds JaCoCo as code coverage tool for Java code.

It also adds a new workflow Code quality check to the repo. This workflow will perform static code analysis, run tests, report code coverage to SonarCloud.

After the first successful execution of the workflow, one can find the code quality data [here](https://sonarcloud.io/summary/new_code?id=JanssenProject_jans-fido2).