### PR TITLE
fix: move up Jans maven repo in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,11 @@
 			<url>https://repository.jboss.org/nexus/content/groups/public-jboss/</url>
 		</repository>
 		<repository>
+			<id>jans</id>
+			<name>Janssen project repository</name>
+			<url>https://maven.jans.io/maven</url>
+		</repository>
+		<repository>
 			<id>gluu</id>
 			<name>gluu repository</name>
 			<url>https://ox.gluu.org/maven</url>
@@ -46,11 +51,6 @@
 			<id>mavencentral</id>
 			<name>maven central</name>
 			<url>https://repo1.maven.org/maven2</url>
-		</repository>
-		<repository>
-			<id>jans</id>
-			<name>Janssen project repository</name>
-			<url>https://maven.jans.io/maven</url>
 		</repository>
 		<repository>
 			<id>bouncycastle</id>


### PR DESCRIPTION
This change moves Jans maven repo before Gluu maven repo in pom.xml.

With this change, jans artifacts will take precedence over versions stored in Gluu maven repo during build. This reduces risk of modules referring to old versions of dependencies stored in Gluu maven repo.